### PR TITLE
RDKEMW-2899: Add PID and Thread ID to core_log.txt

### DIFF
--- a/recipes-core/sysctl/files/50-sysctl.conf
+++ b/recipes-core/sysctl/files/50-sysctl.conf
@@ -1,4 +1,4 @@
-kernel.core_pattern = |/lib/rdk/core_shell.sh %e %s %t
+kernel.core_pattern = |/lib/rdk/core_shell.sh %e %s %t %p %i
 
 fs.protected_regular = 0
 


### PR DESCRIPTION
Reason for change: Add PID and TID support
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)