### PR TITLE
RDK-56570 : Standardize Volatile Binds Management

### DIFF
--- a/conf/distro/include/rdkv.inc
+++ b/conf/distro/include/rdkv.inc
@@ -90,10 +90,6 @@ PREFERRED_VERSION_mosquitto:kirkstone = "2.0.14"
 PREFERRED_VERSION_nodejs:kirkstone = "16.14.2"
 PREFERRED_VERSION_nodejs-native:kirkstone = "16.14.2"
 
-VOLATILE_BINDS:append = "/tmp/named.conf.options /etc/bind/named.conf.options\n"
-VOLATILE_BINDS:append = "/tmp/bind /var/cache/bind\n"
-VOLATILE_BINDS:append = "/tmp/stunnel.conf /etc/stunnel.conf\n"
-
 PREFERRED_VERSION_qtwebsockets = "${@bb.utils.contains('DISTRO_FEATURES', 'comcast_qt5', '5.1.1%', '5.15.7', d)}"
 
 

--- a/conf/distro/rdk.conf
+++ b/conf/distro/rdk.conf
@@ -248,7 +248,11 @@ VOLATILE_BINDS:append:client = "/tmp/timesyncd.conf /etc/systemd/timesyncd.conf\
 VOLATILE_BINDS:append:hybrid = "/tmp/udhcpc.vendor_specific /etc/udhcpc.vendor_specific\n"
 VOLATILE_BINDS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', '', '/tmp/dibbler /etc/dibbler\n' , d)}"
 VOLATILE_BINDS:append = " /var/volatile/xupnp /etc/xupnp\n "
-VOLATILE_BINDS:append = "/tmp/samhain /var/samhain\n"
+VOLATILE_BINDS:append = "/tmp/named.conf.options /etc/bind/named.conf.options\n"
+VOLATILE_BINDS:append = "/tmp/bind /var/cache/bind\n"
+VOLATILE_BINDS:append = "/tmp/stunnel.conf /etc/stunnel.conf\n"
+
+
 
 XZ_COMPRESSION_LEVEL ?= "-e -M 50% -9"
 


### PR DESCRIPTION
Reason For Change : 
Framework to parse bind configs and generate service dynamically
Consolidate Bind configurations
Test Procedure : Add bind configs and inherit the Framework in Package group
Signed-off-by : [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)