### PR TITLE
RDKEMW-5066: Install RBUS Test binaries only when RBUS_ENABLE_TEST_APPS distro enabled

### DIFF
--- a/conf/distro/include/rdkb.inc
+++ b/conf/distro/include/rdkb.inc
@@ -146,4 +146,7 @@ DISTRO_FEATURES:append = " safec"
 DISTRO_FEATURES:append = " webui_jst"
 #DISTRO_FEATURES:append = " gtestapp"
 DISTRO_FEATURES:append = " redrecovery"
+# Distro feature for installing RBUS_TEST_APPS
+DISTRO_FEATURES:append = "RBUS_ENABLE_TESTAPPS"
+
 OPTIMIZE_DEFAULT = "-Os"

--- a/conf/distro/include/rdkv.inc
+++ b/conf/distro/include/rdkv.inc
@@ -141,3 +141,6 @@ DISTRO_FEATURES:append = " ENABLE_NETWORKMANAGER"
 
 #Distro feature for WPEFramework SecurityUtility Disable
 DISTRO_FEATURES:append = " wpe_security_util_disable"
+
+# Distro feature for installing RBUS_TEST_APPS
+DISTRO_FEATURES:append = "RBUS_ENABLE_TESTAPPS"

--- a/recipes-common/rbus/rbus.bb
+++ b/recipes-common/rbus/rbus.bb
@@ -35,8 +35,8 @@ EXTRA_OECMAKE += " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '-DENABLE
 EXTRA_OECMAKE += " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '-DBUILD_RBUS_BENCHMARK_TEST=ON -DBUILD_RBUS_UNIT_TEST=ON -DBUILD_RBUS_SAMPLE_APPS=ON', '', d)}"
 DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', ' gtest benchmark ', ' ', d)}"
 
-#Avoid install RBus test binariesAdd commentMore actions
-EXTRA_OECMAKE += " ${@bb.utils.contains_any('DISTRO_FEATURES', 'prod-variant prodlog-variant', '-DBUILD_RBUS_SAMPLE_APPS=OFF -DBUILD_RBUS_TEST_APPS=OFF', '', d)}"
+#Install RBus test binaries
+EXTRA_OECMAKE += " ${@bb.utils.contains('DISTRO_FEATURES', 'RBUS_ENABLE_TESTAPPS', '-DBUILD_RBUS_SAMPLE_APPS=ON -DBUILD_RBUS_TEST_APPS=ON', '', d)}"
 
 #Dunfell Specific CFlags
 CFLAGS:append = " -Wno-format-truncation "


### PR DESCRIPTION
Reason for change: Avoiding uneccessary files
Test Procedure: Test and verified
Risks: Medium
Priority: P1