### PR TITLE
RDKEMW-5066: Install RBUS Test binaries only when RBUS_ENABLE_TEST_AP…

### DIFF
--- a/recipes-common/rbus/rbus.bb
+++ b/recipes-common/rbus/rbus.bb
@@ -10,7 +10,7 @@ SRCREV = "ce10ff2246632f232aa91d6723cfae123972ebe1"
 SRCREV_FORMAT = "base"
 
 PV ?= "2.5.0"
-PR ?= "r0"
+PR ?= "r1"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -32,11 +32,9 @@ EXTRA_OECMAKE += " -DMSG_ROUNDTRIP_TIME=ON -DENABLE_RDKLOGGER=ON"
 
 #Gtest Specific Enablements
 EXTRA_OECMAKE += " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '-DENABLE_UNIT_TESTING=ON', '', d)}"
-EXTRA_OECMAKE += " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '-DBUILD_RBUS_BENCHMARK_TEST=ON -DBUILD_RBUS_UNIT_TEST=ON -DBUILD_RBUS_SAMPLE_APPS=ON', '', d)}"
-DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', ' gtest benchmark ', ' ', d)}"
-
-#Avoid install RBus test binariesAdd commentMore actions
-EXTRA_OECMAKE += " ${@bb.utils.contains_any('DISTRO_FEATURES', 'prod-variant prodlog-variant', '-DBUILD_RBUS_SAMPLE_APPS=OFF -DBUILD_RBUS_TEST_APPS=OFF', '', d)}"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', ' gtest ', ' ', d)}"
+DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'RBUS_ENABLE_TESTAPPS', ' benchmark ', ' ', d)}"
+EXTRA_OECMAKE += " ${@bb.utils.contains('DISTRO_FEATURES', 'RBUS_ENABLE_TESTAPPS', '-DBUILD_RBUS_SAMPLE_APPS=ON -DBUILD_RBUS_TEST_APPS=ON -DBUILD_RBUS_BENCHMARK_TEST=ON', '-DBUILD_RBUS_SAMPLE_APPS=OFF -DBUILD_RBUS_TEST_APPS=OFF -DBUILD_RBUS_BENCHMARK_TEST=OFF', d)}"
 
 #Dunfell Specific CFlags
 CFLAGS:append = " -Wno-format-truncation "


### PR DESCRIPTION
…PS distro enabled (#130)

* RDKEMW-5066: Install RBUS Test binaries only when RBUS_ENABLE_TEST_APPS distro enabled

Reason for change: Avoiding uneccessary files
Test Procedure: Test and verified
Risks: Medium
Priority: P1



* Addressed review comments



* Update rdkb.inc



* Update rbus.bb

* Update rbus.bb

* Removed gtest patch



* Added gtest patch



---------