### PR TITLE
RDKTV-34129: [WebKitBrowser] Use SIGHUP for suspended web process

### DIFF
--- a/recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb
+++ b/recipes-extended/webkitbrowser-plugin/webkitbrowser-plugin_git.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://../LICENSE;md5=16cf2209d4e903e4d5dcd75089d7dfe2"
 
 # keep PV/PR in sync with meta-middleware-generic-support/conf/include/generic-pkgrev.inc
-PV ?= "1.1.27"
+PV ?= "1.1.30"
 PR ?= "r0"
 PATCHTOOL = "git"
 
@@ -20,8 +20,8 @@ SRC_URI = "git://github.com/rdkcentral/rdkservices.git;protocol=git;branch=main 
   file://0008-Thunder-upgrade-quirks.patch;patchdir=../ \
 "
 
-# Tip of the main at Dec 18, 2024
-SRCREV = "d6d87d24468970fe94d692a7b0efbb77e8fe1547"
+# Tip of the main at June 27, 2025
+SRCREV = "857eff8cdcf0a3506683043d0676d541e48dfaa3"
 
 inherit cmake pkgconfig python3native
 


### PR DESCRIPTION
For suspended callsing use SIGHUP to kill unresponsive WebProcess (instead of SIGFPE) to skip minidump report.

In suspended state webkit browser plugin kills web process immediately on the very first unresponsiveness that produces false crash reports.

Reason for change: Fix crash report on browser shutdown
Test Procedure: Webapps smoke testing (launch and exit)
Priority: P1
Risks: Low