### PR TITLE
DELIA-68069 : Enhance to handle the unsupported gamepad

### DIFF
--- a/recipes-connectivity/bluetooth/bluetooth-core_git.bb
+++ b/recipes-connectivity/bluetooth/bluetooth-core_git.bb
@@ -23,6 +23,10 @@ S = "${WORKDIR}/git"
 CFLAGS:append:morty = " -DMORTY_BUILD"
 CFLAGS:append:daisy = " -DMORTY_BUILD"
 
+# BT unsupported gamepad feature enabled
+ENABLE_UNSUPPORT_GAMEPAD = "--enable-unsupportedgamepad=${@bb.utils.contains('DISTRO_FEATURES', 'disable_unsupported_gamepad','no','yes',d)}"
+EXTRA_OECONF += " ${ENABLE_UNSUPPORT_GAMEPAD} "
+
 ENABLE_BTR_IFCE = "--enable-btr-ifce=${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', \
                                             bb.utils.contains('DISTRO_FEATURES', 'gdbus_bluez5', 'gdbus_bluez5', \
                                                 bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5', 'bluez4', d), d), 'none', d)}"


### PR DESCRIPTION
Reason for change: unsupported event handling
Test Procedure: Xbox gen4 pairing functionality

Risks: Low
Priority: P2