### PR TITLE
RDK-58744: Move dependency to service that needs it

### DIFF
--- a/recipes-extended/webkitbrowser-plugin/files/webkit-browser-cache-cleanup.service
+++ b/recipes-extended/webkitbrowser-plugin/files/webkit-browser-cache-cleanup.service
@@ -2,11 +2,13 @@
 Description=Cleans up browser cache
 
 After=local-fs.target storagemgrmain.service
-Before=wpeframework.service
 
 [Service]
 Type=oneshot
 ExecStart=-/bin/sh -c '/lib/rdk/clearWebkitBrowserCache.sh'
+# Ensure this service runs only once ever after boot, independently
+# of other services being restarted that depend on this one
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Services that require this cache cleanup service to run, shall specify the dependency to it to avoid platform or product specific dependencies in generic layers.

Ensure this service runs only once on each boot, if required.