### PR TITLE
 RDKB-60970: RDKLogger OpenSource Migration

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -4,10 +4,10 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-PV = "2.0.0"
+PV = "2.2.0"
 PR = "r0"
 
-SRCREV = "0087a47dbc6c28905f7fd4424a43ed1fc8874389"
+SRCREV = "v2.2.0"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk_logger;protocol=https;branch=main"
 


### PR DESCRIPTION
Reason for change: To have single version of rdklogger across RDKB, RDKV, RDKC & RDKE Test Procedure: Tested and verified
Risks:Medium
Priority:P1

Signed-off-by: dshett549 <DEEPTHICHANDRASHEKAR_SHETTY@comcast.com>