### PR TITLE
RDKEMW-8528: Remove logMilestone.sh & use Binary implementation (#268)

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -3,15 +3,14 @@ SECTION = "console/utils"
 
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
-PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-PV = "2.0.0"
-PR = "r0"
-
-SRCREV = "0087a47dbc6c28905f7fd4424a43ed1fc8874389"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk_logger;protocol=https;branch=main"
-
 S = "${WORKDIR}/git"
+SRCREV = "v2.3.0"
+PV = "2.3.0"
+PR = "r1"
+PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
+
 
 DEPENDS = "log4c glib-2.0"
 DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', ' safec', " ", d)}"
@@ -31,7 +30,7 @@ LDFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', ' `pkg-confi
 
 do_install:append () {
     install -d ${D}${base_libdir}/rdk/
-    install -m 0755 ${S}/scripts/logMilestone.sh ${D}${base_libdir}/rdk
+    install -m 0755 ${D}${bindir}/rdkLogMileStone ${D}${base_libdir}/rdk/logMilestone.sh
 }
 
 FILES:${PN} += "${base_libdir}/rdk/logMilestone.sh \


### PR DESCRIPTION
Reason for change: For optimization
Test Procedure: Tested and verified
Risks:Medium
Priority:P1