### PR TITLE
RDKEMW-8528: Avoiding cimplog to install onboarding_log bin (#297)

### DIFF
--- a/recipes-support/cimplog/cimplog_1.0.bb
+++ b/recipes-support/cimplog/cimplog_1.0.bb
@@ -15,10 +15,8 @@ PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 
 S = "${WORKDIR}/git"
-CFLAGS:append += " ${@bb.utils.contains('DISTRO_FEATURES', 'bci', '', '-DFEATURE_SUPPORT_ONBOARD_LOGGING',d)}"
 inherit pkgconfig cmake
 EXTRA_OECMAKE += "-DRDK_LOGGER=ON -DBUILD_TESTING=OFF -DBUILD_YOCTO=true"
-EXTRA_OECMAKE:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'bci', '', ' -DFEATURE_SUPPORT_ONBOARD_LOGGING=true',d)}"
 
 ASNEEDED_hybrid = ""
 ASNEEDED_client = ""


### PR DESCRIPTION
Reason for change: Avoiding cimplog to install onboarding_log bin which is already installed by rdklogger  Test Procedure: Tested and verified
Risks:Medium
Priority:P0