### PR TITLE
RDKEMW-8528: Remove logMilestone.sh installation from rdk-logger

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -28,13 +28,7 @@ CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec',  ' `pkg-confi
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', '', ' -DSAFEC_DUMMY_API', d)}"
 LDFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', ' `pkg-config --libs libsafec`', '', d)}"
 
-do_install:append () {
-    install -d ${D}${base_libdir}/rdk/
-    install -m 0755 ${D}${bindir}/rdkLogMileStone ${D}${base_libdir}/rdk/logMilestone.sh
-}
-
-FILES:${PN} += "${base_libdir}/rdk/logMilestone.sh \
-                /rdkLogMileStone \
+FILES:${PN} += "/rdkLogMileStone \
                 /rdklogctrl \
                 ${base_libdir} \
                 ${base_libdir}/rdk"


### PR DESCRIPTION
Reason for change:  Remove logMilestone.sh installation from rdk-logger
Test Procedure: Verify Milestone logs.
Risks: Low
