### PR TITLE
RDKEMW-9549  : Revert "RDKEMW-8528: Remove logMilestone.sh & use Binary implementation (#268)"

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -8,7 +8,7 @@ SRC_URI = "${CMF_GITHUB_ROOT}/rdk_logger;protocol=https;branch=main"
 S = "${WORKDIR}/git"
 SRCREV = "v2.3.0"
 PV = "2.3.0"
-PR = "r1"
+PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 


### PR DESCRIPTION
This reverts commit 95412cc4cbd53927f6d1ad6503ba4410d9beeecb.