### PR TITLE
RDKEMW-9910: Sync with RDKV to support new game controllers - backport to RDKE8.3

### DIFF
--- a/recipes-extended/wpe-backend-rdk/files/comcast-manette-gamepad-digital-trigger-fix.patch
+++ b/recipes-extended/wpe-backend-rdk/files/comcast-manette-gamepad-digital-trigger-fix.patch
@@ -1,0 +1,45 @@
+From 58edd7b033735308afc25c9c0fe36e2a969d5f55 Mon Sep 17 00:00:00 2001
+From: Ganesh prasad Sahu <GaneshPrasad_Sahu@comcast.com>
+Date: Thu, 1 May 2025 18:37:24 +0000
+Subject: [PATCH] comcast manette gamepad digital trigger fix
+Source: COMCAST 
+Signed-off-by: Ganesh Sahu <ganeshprasad_sahu@comcast.com>
+
+---
+ src/manettegamepad/manette_gamepad.cpp | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/manettegamepad/manette_gamepad.cpp b/src/manettegamepad/manette_gamepad.cpp
+index c4f1a04..547e8f8 100644
+--- a/src/manettegamepad/manette_gamepad.cpp
++++ b/src/manettegamepad/manette_gamepad.cpp
+@@ -169,9 +169,11 @@ struct GamepadProvider
+     double value = 1.0;
+     if (!manette_event_get_button(event, &button))
+         return;
+-    if (button == BTN_TL2 || button == BTN_TR2) {
++    //Send button pressed with absolute value if an analog trigger
++    if ( (button == BTN_TL2 || button == BTN_TR2) && manette_device_trigger_type(device) ) {
+        manette_event_get_button_value(event, &value);
+        provider->analogButtonChanged(device, toStandardGamepadButton(button), value);
++       //g_warning("manette-gamepad: buttonPressEvent btn=%u (analog=y) val=%lf\n",button, value);
+     }
+     else
+       provider->buttonPressedOrReleased(device, toStandardGamepadButton(button), true);
+@@ -183,9 +185,12 @@ struct GamepadProvider
+     double value = 0.0;
+     if (!manette_event_get_button(event, &button))
+         return;
+-    if (button == BTN_TL2 || button == BTN_TR2) {
++
++    //Send button released with absolute value if an analog trigger
++    if ( (button == BTN_TL2 || button == BTN_TR2) && manette_device_trigger_type(device) ) {
+        manette_event_get_button_value(event, &value);
+        provider->analogButtonChanged(device, toStandardGamepadButton(button), value);
++       //g_warning("manette-gamepad: buttonReleaseEvent btn=%u (analog=y) val=%lf\n",button, value);
+     }
+     else
+       provider->buttonPressedOrReleased(device, toStandardGamepadButton(button), false);
+-- 
+2.25.1
+

--- a/recipes-extended/wpe-backend-rdk/wpe-backend-rdk_0.5.bb
+++ b/recipes-extended/wpe-backend-rdk/wpe-backend-rdk_0.5.bb
@@ -22,6 +22,7 @@ SRC_URI += "file://0001-Fix-browser-crash-when-the-compositor-is-not-created.pat
 SRC_URI += "file://0001-Send-SIGHUP-if-compositor-is-terminated.patch"
 SRC_URI += "file://comcast-manette-gamepad-support.patch"
 SRC_URI += "file://comcast-manette-gamepad-analog-button.patch"
+SRC_URI += "file://comcast-manette-gamepad-digital-trigger-fix.patch"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
RDKEMW-9910: Sync with RDKV to support new game controllers - backport to RDKE8.3

Reason for change: Backport the changes from RDKV and develop branch
- Add digital trigger support and fix D-Pad keys
- Update gamecontroller database to support key mapping for new controllers
Test Procedure: As per ticket
Risks: Low
Priority: P2
Signed-off-by: Ganesh prasad Sahu <GaneshPrasad_Sahu@comcast.com>

(cherry picked from commit 31f79e91eb14c5d18f91f07d388e3b36f54e4aaf)