### PR TITLE
RDKEMW-8825 : App Not Killed by Dobby OOM at Max Memory Limit (#285)

### DIFF
--- a/recipes-containers/dobby/dobby.bb
+++ b/recipes-containers/dobby/dobby.bb
@@ -8,6 +8,7 @@ SRC_URI:append = " file://Fix_compile_gcc11.patch  \
                    file://Add_config_header_kirkstone.patch \
                    file://dobby.generic.json \
                    file://dobby_start_after_apparmor.patch \
+                   file://0001-RDKEMW-8825-enable-swap-limit.patch \
                  "
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"

--- a/recipes-containers/dobby/files/0001-RDKEMW-8825-enable-swap-limit.patch
+++ b/recipes-containers/dobby/files/0001-RDKEMW-8825-enable-swap-limit.patch
@@ -1,0 +1,45 @@
+From 9f066586771a436a11521bcafb99211852afcc2a Mon Sep 17 00:00:00 2001
+From: Gurdal Oruklu <gurdal_oruklu@comcast.com>
+Date: Mon, 29 Sep 2025 22:14:13 +0000
+Subject: [PATCH] RDKEMW-8825: App not killed when container reaches memory
+ limit
+
+Added "swap" limit in the OCI config templates to enable OOM killing when
+memory limit is reached when swap memory is enabled.
+
+Signed-off-by: Gurdal Oruklu <gurdal_oruklu@comcast.com>
+---
+ bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template | 4 +++-
+ .../lib/source/templates/OciConfigJsonVM1.0.2-dobby.template  | 4 +++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+index 381017098..6cbdabd43 100644
+--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
++++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+@@ -327,7 +327,9 @@ static const char* ociJsonTemplate = R"JSON(
+                 {{/DEV_WHITELIST_SECTION}}
+             ],
+             "memory": {
+-                "limit": {{MEM_LIMIT}}
++                "limit": {{MEM_LIMIT}},
++                "swap": {{MEM_LIMIT}},
++                "swappiness": 60
+             },
+             "cpu": {
+                 {{#CPU_SHARES_ENABLED}}
+diff --git a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+index ed1bc177f..21fe91d38 100644
+--- a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
++++ b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+@@ -338,7 +338,9 @@ static const char* ociJsonTemplate = R"JSON(
+                 {{/DEV_WHITELIST_SECTION}}
+             ],
+             "memory": {
+-                "limit": {{MEM_LIMIT}}
++                "limit": {{MEM_LIMIT}},
++                "swap": {{MEM_LIMIT}},
++                "swappiness": 60
+             },
+             "cpu": {
+                 {{#CPU_SHARES_ENABLED}}


### PR DESCRIPTION
Reason for change: enable swap limit in OCI config template
Test Procedure: see Jira ticket
Risks: Low
Priority: P1

Change-Id: Iaf7683fbcdfe697f2fdc14c388fa66b050a3d093