### PR TITLE
RDKEMW-10417 : Move common_utils recipe to meta-rdk layer

### DIFF
--- a/recipes-common/utils/commonutilities_git.bb
+++ b/recipes-common/utils/commonutilities_git.bb
@@ -15,7 +15,7 @@ CFLAGS += "${@bb.utils.contains('DISTRO_FEATURES', 'debug_curl_cdl', ' -DCURL_DE
 
 CFLAGS:append = " -DRDK_LOGGER"
 
-PV ?= "1.4.3"
+PV ?= "1.4.4"
 PR ?= "r0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
RDKEMW-10417 : Move common_utils recipe to meta-rdk layer

Reason for change: Moving common utils recipe to meta-rdk layer
Test Procedure: Check image upgrade and downgrade
Risks: Low
Priority: P1
Signed-off-by: Tirumala, Madhubabu (Contractor) [Madhubabu_Tirumala@comcast.com](mailto:Madhubabu_Tirumala@comcast.com)