### PR TITLE
Simplify status dropdown in middleware change request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/middleware_change_request.yml
+++ b/.github/ISSUE_TEMPLATE/middleware_change_request.yml
@@ -31,22 +31,105 @@ body:
       value: |
         ---
         ## Definition of Done (DoD)
-        
-        Update the status and details for each item as you work on this Change Request.
-  
-  - type: textarea
-    id: dod-checklist
+        Please select the status and provide details for each item below.
+
+  # --- DoD Item 1 ---
+  - type: dropdown
+    id: dod-status-1
     attributes:
-      label: Definition of Done Checklist
-      description: Track progress on completion criteria. Update status and add details as you progress.
-      value: |
-        | Status | DoD Item | Details |
-        |--------|----------|---------|
-        | Yes / No / NA | Middleware component tags with changelog | https://github.com/rdk-e/netmonitor/blob/1.4.0/CHANGELOG.md <br> |
-        | Yes / No / NA | Impact on Devices - STBs (Realtek, Broadcom), TVs (Amlogic, MediaTek) |  |
-        | Yes / No / NA | Dependent components	 | If a feature involves more than one component changes, link the dependent component release task ticket clarifying the dependency |
-        | Yes / No / NA | Layer tags | Tags released for OSS/OE repos, Layer release, product repo, build-support, RDKE config into middleware manifest <br> eg: https://github.com/rdk-e/meta-image-support/blob/4.1.1/CHANGELOG.md <br> |
-        | Yes / No / NA | Do Widgets Need Publishing  | |
-        | Yes / No / NA | Copilot review Done | |
+      label: 1. Middleware component tags with changelog
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
     validations:
       required: true
+  - type: input
+    id: dod-details-1
+    attributes:
+      label: Details for Item 1
+      placeholder: "Link e.g. https://github.com/rdk-e/netmonitor/blob/1.4.0/CHANGELOG.md"
+
+  # --- DoD Item 2 ---
+  - type: dropdown
+    id: dod-status-2
+    attributes:
+      label: 2. Impact on Devices (STBs, TVs)
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: input
+    id: dod-details-2
+    attributes:
+      label: Details for Item 2
+      placeholder: "Notes on Realtek, Broadcom, Amlogic, MediaTek..."
+
+  # --- DoD Item 3 ---
+  - type: dropdown
+    id: dod-status-3
+    attributes:
+      label: 3. Dependent components
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: input
+    id: dod-details-3
+    attributes:
+      label: Details for Item 3
+      description: "If a feature involves more than one component changes, link the dependent component release task ticket clarifying the dependency"
+
+  # --- DoD Item 4 ---
+  - type: dropdown
+    id: dod-status-4
+    attributes:
+      label: 4. Layer tags
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: input
+    id: dod-details-4
+    attributes:
+      label: Details for Item 4
+      description: "Tags released for OSS/OE repos, Layer release, product repo, build-support, RDKE config into middleware manifest"
+      placeholder: "e.g: https://github.com/rdk-e/meta-image-support/blob/4.1.1/CHANGELOG.md"
+
+  # --- DoD Item 5 ---
+  - type: dropdown
+    id: dod-status-5
+    attributes:
+      label: 5. Do Widgets Need Publishing
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: input
+    id: dod-details-5
+    attributes:
+      label: Details for Item 5
+
+  # --- DoD Item 6 ---
+  - type: dropdown
+    id: dod-status-6
+    attributes:
+      label: 6. Copilot review Done
+      options:
+        - "Yes"
+        - "No"
+        - "N/A"
+    validations:
+      required: true
+  - type: input
+    id: dod-details-6
+    attributes:
+      label: Details for Item 6


### PR DESCRIPTION
This PR simplifies the status dropdown options in the middleware change request issue template to improve usability and clarity.