### PR TITLE
Fix: Update middleware change request template labels and add DoD guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/middleware_change_request.yml
+++ b/.github/ISSUE_TEMPLATE/middleware_change_request.yml
@@ -32,6 +32,15 @@ body:
         ---
         ## Definition of Done (DoD)
         
+        Please complete the following Middleware Layer Integration checklist items to ensure all requirements for changes to be merged.
+        
+        **IMPORTANT:** Do NOT provide any proprietary information including:
+        - Links to internal Automatics/CI builds
+        - Links to internal Confluence pages
+        - Any other Comcast/Sky proprietary or confidential information
+        
+        Only provide publicly accessible information and links.
+        
   - type: checkboxes
     id: dod-1
     attributes:

--- a/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
+++ b/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
@@ -1,0 +1,68 @@
+name: RDK-E Middleware Change Request
+description: Change Request for RDK-E Middleware
+title: "<JIRA TICKET>:<Ticket Title> "
+labels: ["MW Change Request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Change Request for RDK-E Middleware
+  
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Provide a clear and concise description of the feature or bug ticket
+      placeholder: Describe the changes you are bringing
+    validations:
+      required: true
+  
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or examples about the feature request
+      placeholder: Any other relevant information
+    validations:
+      required: false
+  
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ## Definition of Done (DoD)
+        
+        Please complete the following Middleware Layer Integration checklist items to ensure all requirements for changes to be merged.
+        
+        **IMPORTANT:** Do NOT provide any proprietary information including:
+        - Links to internal Automatics/CI builds
+        - Links to internal Confluence pages
+        - Any other Comcast/Sky proprietary or confidential information
+        
+        Only provide publicly accessible information and links.
+        
+  - type: textarea
+    id: dod-checklist
+    attributes:
+      label: DoD Checklist
+      description: Mark items with [x] and provide details in the line below.
+      value: |
+        - [ ] **Middleware component tags with changelog**
+          - Details: https://github.com/rdk-e/netmonitor/blob/1.4.0/CHANGELOG.md
+
+        - [ ] **Impact on Devices (STBs, TVs)**
+          - Details: (Notes on Realtek, Broadcom, Amlogic, MediaTek...)
+
+        - [ ] **Dependent components**
+          - Details: (Link dependent component release task if applicable)
+
+        - [ ] **Layer tags**
+          - Details: (e.g. https://github.com/rdk-e/meta-image-support/blob/4.1.1/CHANGELOG.md)
+
+        - [ ] **Do Widgets Need Publishing**
+          - Details: (Provide context if widgets are involved)
+
+        - [ ] **Copilot review Done**
+          - Details: (Any comments on the review)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
+++ b/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
@@ -1,4 +1,4 @@
-name: RDK-E Middleware Change Request
+name: RDK-E Middleware Change Request Compact
 description: Change Request for RDK-E Middleware
 title: "<JIRA TICKET>:<Ticket Title> "
 labels: ["MW Change Request"]

--- a/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
+++ b/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
@@ -45,7 +45,7 @@ body:
     id: dod-checklist
     attributes:
       label: DoD Checklist
-      description: Mark items with [x] and provide details in the line below.
+      description: Mark items with [x] and replace the placeholder text on Details lines with actual information.
       value: |
         - [ ] **Middleware component tags with changelog**
           - Details: https://github.com/rdk-e/netmonitor/blob/1.4.0/CHANGELOG.md

--- a/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
+++ b/.github/ISSUE_TEMPLATE/middleware_change_request_compact.yml
@@ -48,21 +48,21 @@ body:
       description: Mark items with [x] and replace the placeholder text on Details lines with actual information.
       value: |
         - [ ] **Middleware component tags with changelog**
-          - Details: https://github.com/rdk-e/netmonitor/blob/1.4.0/CHANGELOG.md
+        - Details: https://github.com/rdk-e/netmonitor/blob/1.4.0/CHANGELOG.md
 
         - [ ] **Impact on Devices (STBs, TVs)**
-          - Details: (Notes on Realtek, Broadcom, Amlogic, MediaTek...)
+        - Details: (Notes on Realtek, Broadcom, Amlogic, MediaTek...)
 
         - [ ] **Dependent components**
-          - Details: (Link dependent component release task if applicable)
+        - Details: (Link dependent component release task if applicable)
 
         - [ ] **Layer tags**
-          - Details: (e.g. https://github.com/rdk-e/meta-image-support/blob/4.1.1/CHANGELOG.md)
+        - Details: (e.g. https://github.com/rdk-e/meta-image-support/blob/4.1.1/CHANGELOG.md)
 
         - [ ] **Do Widgets Need Publishing**
-          - Details: (Provide context if widgets are involved)
+        - Details: (Provide context if widgets are involved)
 
         - [ ] **Copilot review Done**
-          - Details: (Any comments on the review)
+        - Details: (Any comments on the review)
     validations:
       required: true


### PR DESCRIPTION
## Description
This PR fixes GitHub validation errors in the middleware_change_request.yml issue template, adds important guidance for the Definition of Done section, and includes a compact version of the template.

## Changes
- **middleware_change_request.yml:**
  - Replaced empty/whitespace labels with zero-width space characters (​) for all checkbox and input fields
  - Removed comment lines between DoD pairs
  - Added descriptive text under the DoD section explaining the checklist purpose
  - Added warning about NOT providing proprietary information (Automatics/CI builds, Confluence pages, Comcast/Sky proprietary info)

- **middleware_change_request_compact.yml (NEW):**
  - Compact version using a single textarea for all DoD items
  - Includes the same proprietary information warning
  - Provides better user experience with less spacing between items

## Validation Errors Fixed
- body[4] through body[15]: label must be of type String and cannot be empty

## Testing
Both templates will be automatically validated by GitHub when this PR is merged.