### PR TITLE
RDKEMW-10792 : Initial code drop to avoid redundant logging

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -27,6 +27,10 @@ CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec',  ' `pkg-confi
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', '', ' -DSAFEC_DUMMY_API', d)}"
 LDFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', ' `pkg-config --libs libsafec`', '', d)}"
 
+do_configure:prepend () {
+    sed -i 's/layout="comcast_dated"/layout="basic"/' ${S}/log4crc
+}
+
 do_install:append () {
     install -d ${D}${base_libdir}/rdk/
     install -m 0755 ${S}/scripts/logMilestone.sh ${D}${base_libdir}/rdk


### PR DESCRIPTION
Reason for change: Initial code drop to avoid redundant logging
Test Procedure: Verify the timestamp in logs
Risks: Low