### PR TITLE
RDKEMW-10792: Use syslog supported version of RDKLogger

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -18,7 +18,7 @@ PROVIDES = "getClockUptime"
 #Milestone Support
 CFLAGS:append = " -DLOGMILESTONE"
 
-inherit autotools pkgconfig coverity pkgconfig
+inherit autotools pkgconfig coverity
 
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec',  ' `pkg-config --cflags libsafec`', '-fPIC', d)}"
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', '', ' -DSAFEC_DUMMY_API', d)}"


### PR DESCRIPTION
RDKEMW-10792: Use syslog supported version of RDKLogger

Reason for change:
1. Added support for syslog
2. Added support for systemd_journal
3. Added explicit support for file capture
4. Added different formatting capability
5. Added Dynamic re-configuration of format, output handler
6. Added milestone log location
7. Added `comcast_dated` format
8. Added legacy MACRO

Risks:Medium
Priority:P1