### PR TITLE
rebase

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -6,24 +6,21 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk_logger;protocol=https;branch=main"
 S = "${WORKDIR}/git"
-SRCREV = "ed3a3f71b8db836449bde6b7c9dc60438fedf30e"
-PV = "2.4.0"
+SRCREV = "eacd6915758e48b62fbb011d94f1b0ffe67ec4ef"
+PV = "3.0.0"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-
 
 DEPENDS = "log4c glib-2.0"
 DEPENDS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', ' safec', " ", d)}"
 
-#Milestone Support
-EXTRA_OECONF += " --enable-milestone"
 PROVIDES = "getClockUptime"
+#Milestone Support
 CFLAGS:append = " -DLOGMILESTONE"
 
-inherit autotools pkgconfig coverity pkgconfig
+inherit autotools pkgconfig coverity
 
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec',  ' `pkg-config --cflags libsafec`', '-fPIC', d)}"
-
 CFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', '', ' -DSAFEC_DUMMY_API', d)}"
 LDFLAGS:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'safec', ' `pkg-config --libs libsafec`', '', d)}"
 


### PR DESCRIPTION
* RDKEMW-10792: Use syslog supported version of RDKLogger

RDKEMW-10792: Use syslog supported version of RDKLogger

Reason for change:
1. Added support for syslog
2. Added support for systemd_journal
3. Added explicit support for file capture
4. Added different formatting capability
5. Added Dynamic re-configuration of format, output handler
6. Added milestone log location
7. Added `comcast_dated` format
8. Added legacy MACRO

Risks:Medium
Priority:P1