### PR TITLE
RDKOSS-602: RDKE][Middleware][All components] Use IPK instead of build from source

### DIFF
--- a/conf/distro/rdk.conf
+++ b/conf/distro/rdk.conf
@@ -389,3 +389,23 @@ PREFERRED_PROVIDER_virtual/ca-certificates-trust-store ?= "ca-certificates-trust
 PREFERRED_PROVIDER_virtual/firebolt ?= "ripple"
 
 include conf/distro/rdk-cpc.conf
+#MW IPK MODE
+RDK_MW_ARCH ??= "${MACHINE}"
+
+MIDDLEWARE_ARCH = "${RDK_MW_ARCH}-middleware"
+STACK_LAYER_EXTENSION = "${MIDDLEWARE_ARCH}"
+RELEASE_NUM = "8.4.1.0"
+
+MW_IPK_PATH ?= "middleware-rel/${RELEASE_NUM}"
+MW_IPK_SERVER_PATH ?= "${RDK_ARTIFACTS_BASE_URL}/${MW_IPK_PATH}/${RDK_MW_ARCH}/ipks/${BUILD_VARIANT}"
+IPK_FEED_URIS += " \
+                ${STACK_LAYER_EXTENSION}##${MW_IPK_SERVER_PATH} "
+				
+#OSS IPK MODE
+MW_EXTENSION = "-middleware"
+MW_OSS = "${@get_oss_arch(d)}${MW_EXTENSION}"
+STACK_LAYER_EXTENSION += " ${MW_OSS}"
+OPKG_ARCH_PRIORITY:${MW_OSS} = "205"
+MW_OSS_IPK_PATH ?= "middleware-rel/${RELEASE_NUM}"
+MW_OSS_IPK_SERVER_PATH = "${RDK_ARTIFACTS_BASE_URL}/${MW_OSS_IPK_PATH}/${RDK_MW_ARCH}/${MW_OSS}/ipks/${BUILD_VARIANT}"
+IPK_FEED_URIS += " ${MW_OSS}##${MW_OSS_IPK_SERVER_PATH} "


### PR DESCRIPTION
Reason For Change: To Reduce the build time ,Added some extra lines in this rdk.conf file which helps to enable the ipk mode for both middleware components and Oss Components to fetch the ipk from artifactory.

Test Procedure: None
Risks: low