### PR TITLE
RDKOSS-646: Update the SRCREV to support RDKB

### DIFF
--- a/recipes-common/libunpriv/libunpriv.bb
+++ b/recipes-common/libunpriv/libunpriv.bb
@@ -5,7 +5,7 @@ S = "${WORKDIR}/git"
 PV = "1.0.2"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
-SRCREV_rdk-libunpriv = "547d202d421ed83bd60b677b5d057cad3b7ae8ad"
+SRCREV_rdk-libunpriv = "a0dbea7d368a630158abf56ef8bd7f3855910ec5"
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk-libunpriv.git;${CMF_GITHUB_SRC_URI_SUFFIX};name=rdk-libunpriv"
 
 SRCREV_FORMAT = "rdk-libunpriv"


### PR DESCRIPTION
Reason for change: Update the srcrev to include the changes required for RDKB to build.