### PR TITLE
RDK-60312: Telemetry Release 1.8.0

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bb
+++ b/recipes-common/telemetry/telemetry_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRCREV = "b4171d7741714e1d003abf83c9b4763f7911dbea"
+SRCREV = "5660e9c1811f366837dffb529f93d052c2613857"
 SRC_URI = "${CMF_GITHUB_ROOT}/telemetry;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -14,7 +14,7 @@ DEPENDS += "rdk-logger"
 RDEPENDS:${PN} += "curl cjson glib-2.0 rbus"
 
 
-PV = "1.7.4"
+PV = "1.8.0"
 PR = "r0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Includes:
RDK-60312: Remove fork calls for curl transactions https://github.com/rdkcentral/telemetry/pull/242
RDK-60533: L1 unit test cases - protocol/rbusMethod and http https://github.com/rdkcentral/telemetry/pull/241
RDKB-63348 : Fix duplicate close calls on file descriptor https://github.com/rdkcentral/telemetry/pull/251