### PR TITLE
RDKEMW-14095: Extend the allowed JIRA buckets list in PR title

### DIFF
--- a/.github/workflows/validate_pr_title.yml
+++ b/.github/workflows/validate_pr_title.yml
@@ -18,7 +18,7 @@ jobs:
         PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         # Define valid ticket IDs
-        VALID_TICKET_IDS=("RDKEMW" "RDKEVD" "IMMUI" "RDK")
+        VALID_TICKET_IDS=("RDKEMW" "RDKEVD" "IMMUI" "RDK" "RDKMVE" "RDKDEV")
         
         # Function to validate ticket format and ID
         validate_ticket() {


### PR DESCRIPTION
Reason for change: To allow RDKMVE and RDKDEV JIRA buckets for RDKM & community contribution
Test Procedure: see if newly added JIRA buckets are taken into account and not throwing error during new PR creation
Risks: Low
Signed-off-by: Soundaryaa Sitaram[Soundaryaa_Sitaram@comcast.com](mailto:Soundaryaa_Sitaram@comcast.com)