### PR TITLE
RDKEMW-4941 : bcm bb/bbappend analysis for bluetooth-mgr (#566)

### DIFF
--- a/recipes-connectivity/bluetooth/bluetooth-mgr_git.bb
+++ b/recipes-connectivity/bluetooth/bluetooth-mgr_git.bb
@@ -27,6 +27,9 @@ EXTRA_OECONF = " ${ENABLE_GST1}"
 ENABLE_SAFEC = "--enable-safec=${@bb.utils.contains('DISTRO_FEATURES', 'safec','yes', 'no', d)}"
 EXTRA_OECONF += " ${ENABLE_SAFEC}"
 
+ENABLE_BRCM_BUILD = "--enable-brcm-build=${@bb.utils.contains('DISTRO_FEATURES', 'btr_bcm_pcm_sink','yes', 'no', d)}"
+EXTRA_OECONF += " ${ENABLE_BRCM_BUILD}"
+
 # RPC-IARM Must be Enabled for Video Platforms only; Also iarmbus is dependency for Video Platforms
 DEPENDS:append:client = " iarmbus ${@bb.utils.contains('DISTRO_FEATURES', 'ENABLE_NETWORKMANAGER', '', 'netsrvmgr', d)}"
 DEPENDS:append:hybrid = " iarmbus"


### PR DESCRIPTION
* RDKEMW-4941 : bcm bb/bbappend analysis for bluetooth-mgr.

Reason for change:
Included new distro feature btr_bcm_pcm_sink for Broadcom specific PCM sink support

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: High
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

* Update bluetooth-mgr_git.bb

---------