### PR TITLE
RDKEMW-14300 : Pull RDKLogger latest to get all features of v3.1.0 (#…

### DIFF
--- a/recipes-common/rdk-logger/rdk-logger_git.bb
+++ b/recipes-common/rdk-logger/rdk-logger_git.bb
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/rdk_logger;protocol=https;branch=main"
 S = "${WORKDIR}/git"
-SRCREV = "eacd6915758e48b62fbb011d94f1b0ffe67ec4ef"
-PV = "3.0.0"
+SRCREV = "6dc321d7a5890ef947402532a990ebfb91839f2b"
+PV = "3.1.0"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -30,7 +30,5 @@ do_install:append () {
 }
 
 FILES:${PN} += "${base_libdir}/rdk/logMilestone.sh \
-                /rdkLogMileStone \
-                /rdklogctrl \
                 ${base_libdir} \
                 ${base_libdir}/rdk"


### PR DESCRIPTION
…601)

RDKEMW-14300 : Update RDKLogger to fetch the latest features of v3.1.0

Reason for change:
    1. Removed Log split & truncation
    2. Configured default buffer size to be 0 as same as Previous Releases
    3. Added new log formats as TID & TS_TIDs
    4. Added testApp to measure CPU
    5. Updated default logging to console instead of recently changes syslog
    6. Added unit test cases to verify the new formats
    7. Added unified log function to handle all the log formats
    8. Moved the log4c init to rdklogger init