### PR TITLE
RDK-60312: Telemetry Release 1.8.1

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bb
+++ b/recipes-common/telemetry/telemetry_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRCREV = "5660e9c1811f366837dffb529f93d052c2613857"
+SRCREV = "80657f19eb3c29f4837de13e45ec5a969f946b01"
 SRC_URI = "${CMF_GITHUB_ROOT}/telemetry;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -14,7 +14,7 @@ DEPENDS += "rdk-logger"
 RDEPENDS:${PN} += "curl cjson glib-2.0 rbus"
 
 
-PV = "1.8.0"
+PV = "1.8.1"
 PR = "r0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
RDK-60476: Reduce default connection pool size to 1 https://github.com/rdkcentral/telemetry/pull/260
RDK-60805: Adding L1 unit test cases for reportprofiles https://github.com/rdkcentral/telemetry/pull/265