### PR TITLE
RDKEMW-15664 : handle deepsleep in chrony

### DIFF
--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "3f1103fde012a67d0aad2a4e22ebfa0b0e61b453"
+SRCREV_systemtimemgr = "8d25fe4d00cb69a6a57bcfe9f3dd319ad5abcca0"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "8d25fe4d00cb69a6a57bcfe9f3dd319ad5abcca0"
+SRCREV_systemtimemgr = "0d65bf0900ce6cc043b168dda746adeaeda45dd4"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "8ee691e928fe927e05a07f9e1c10bf6a0ecf089d"
+SRCREV_systemtimemgr = "56a3966eabbfafb44e7e9adaf1d3a9c19896600c"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "31ea3dbf777a5dccc80ae7197050e8a8aa51802f"
+SRCREV_systemtimemgr = "05ec4544019d47032f4d6fa775cac71899cf7bf4"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "05ec4544019d47032f4d6fa775cac71899cf7bf4"
+SRCREV_systemtimemgr = "519f014d1bbfcf2ecc135e25c29676bee022a327"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "
@@ -15,7 +15,7 @@ SRC_URI:append = " file://secure.conf "
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 SRCREV_FORMAT = "systemtimemgr"
-PV = "1.5.0"
+PV = "1.5.1"
 PR = "r0"
 
 CXXFLAGS += " -I${PKG_CONFIG_SYSROOT_DIR}/${includedir}/WPEFramework/powercontroller"

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "56a3966eabbfafb44e7e9adaf1d3a9c19896600c"
+SRCREV_systemtimemgr = "3f1103fde012a67d0aad2a4e22ebfa0b0e61b453"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "84f8f2a299adbb830f30af32b38ece1a2892ed45"
+SRCREV_systemtimemgr = "174c0b36d18b72542253036d528c0d42e3c0ee4e"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "174c0b36d18b72542253036d528c0d42e3c0ee4e"
+SRCREV_systemtimemgr = "31ea3dbf777a5dccc80ae7197050e8a8aa51802f"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "0d65bf0900ce6cc043b168dda746adeaeda45dd4"
+SRCREV_systemtimemgr = "84f8f2a299adbb830f30af32b38ece1a2892ed45"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -55,6 +55,17 @@ if [ ! -f "$CLOCK_EVENT" ]; then
 touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
+if [ ! -d "$SYSTEMD_DIR" ]; then
+    log "Creating $SYSTEMD_DIR"
+    mkdir -p "$SYSTEMD_DIR"
+fi
+
+if [ ! -f "$SYSTEMD_CLOCK" ]; then
+touch "$SYSTEMD_CLOCK" && log "Created $SYSTEMD_CLOCK"
+fi
+
+echo "Synchronized" > /tmp/ntp_status
+
 if [  -d "$NTP_DIR" ]; then
    if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
       log "Created $NTP_FILE"
@@ -66,16 +77,5 @@ else
    log "Directory $NTP_DIR does not exist; cannot create $NTP_FILE"
    exit 1
 fi
-
-if [ ! -d "$SYSTEMD_DIR" ]; then
-    log "Creating $SYSTEMD_DIR"
-    mkdir -p "$SYSTEMD_DIR"
-fi
-
-if [ ! -f "$SYSTEMD_CLOCK" ]; then
-touch "$SYSTEMD_CLOCK" && log "Created $SYSTEMD_CLOCK"
-fi
-
-echo "Synchronized" > /tmp/ntp_status
 
 exit 0

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -58,7 +58,7 @@ fi
 
 touch "/tmp/systimemgr/ntp" && log "Created $NTP_FILE"
 #log "Change the permission of $NTP_FILE"
-#chmod 644 "$NTP_FILE"
+chmod 644 "$NTP_FILE"
 log "Permission changed for $NTP_FILE"
 
 

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -55,13 +55,15 @@ if [ ! -f "$CLOCK_EVENT" ]; then
 touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
-
-if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
-    log "Created $NTP_FILE"
-else
-    log "Failed to create or set permissions on $NTP_FILE"
-    exit 1
+if [  -d "$NTP_DIR" ]; then
+   if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
+      log "Created $NTP_FILE"
+   else
+      log "Failed to create or set permissions on $NTP_FILE"
+      exit 1
+   fi
 fi
+
 if [ ! -d "$SYSTEMD_DIR" ]; then
     log "Creating $SYSTEMD_DIR"
     mkdir -p "$SYSTEMD_DIR"

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -56,8 +56,13 @@ touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
 
-touch "$NTP_FILE" && log "Created $NTP_FILE"
-chmod 644 "$NTP_FILE"
+if touch "$NTP_FILE"; then
+    chmod 644 "$NTP_FILE"
+    log "Created $NTP_FILE"
+else
+    log "Failed to create $NTP_FILE"
+    exit 1
+fi
 
 
 if [ ! -d "$SYSTEMD_DIR" ]; then

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -61,9 +61,12 @@ if [ ! -d "$NTP_DIR" ]; then
 fi
 
 # Create flag files
-if [ ! -f "$NTP_FILE" ]; then
+
 touch "$NTP_FILE" && log "Created $NTP_FILE"
-fi
+log "Change the permission of $NTP_FILE"
+chmod 644 "$NTP_FILE"
+log "Permission changed for $NTP_FILE"
+
 
 if [ ! -d "$SYSTEMD_DIR" ]; then
     log "Creating $SYSTEMD_DIR"

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -29,7 +29,8 @@ SYSTEMD_DIR="/var/lib/systemd/"
 SYSTEMD_CLOCK="$SYSTEMD_DIR/clock"
 
 log() {
-    echo "$1" >> "$LOG_FILE"
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+    echo "$ts chronyd[$$]: $1" >> "$LOG_FILE"
 }
 
 is_synced() {

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -29,9 +29,9 @@ SYSTEMD_DIR="/var/lib/systemd/"
 SYSTEMD_CLOCK="$SYSTEMD_DIR/clock"
 
 log() {
-    ts=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
-    echo "$ts chronyd[$$]: $1" >> "$LOG_FILE"
+    echo "$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ") chronyd[$$]: $1" >> "$LOG_FILE"
 }
+
 
 is_synced() {
     chronyc tracking 2>/dev/null | grep -q "Leap status *: Normal"

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -56,7 +56,7 @@ touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
 
-touch "/tmp/systimemgr/ntp" && log "Created $NTP_FILE"
+touch "$NTP_FILE" && log "Created $NTP_FILE"
 chmod 644 "$NTP_FILE"
 
 

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -57,9 +57,7 @@ fi
 
 
 touch "/tmp/systimemgr/ntp" && log "Created $NTP_FILE"
-#log "Change the permission of $NTP_FILE"
 chmod 644 "$NTP_FILE"
-log "Permission changed for $NTP_FILE"
 
 
 if [ ! -d "$SYSTEMD_DIR" ]; then

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -62,6 +62,9 @@ if [  -d "$NTP_DIR" ]; then
       log "Failed to create or set permissions on $NTP_FILE"
       exit 1
    fi
+else
+   log "Directory $NTP_DIR does not exist; cannot create $NTP_FILE"
+   exit 1
 fi
 
 if [ ! -d "$SYSTEMD_DIR" ]; then

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -29,7 +29,7 @@ SYSTEMD_DIR="/var/lib/systemd/"
 SYSTEMD_CLOCK="$SYSTEMD_DIR/clock"
 
 log() {
-    echo "$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ") chronyd[$$]: $1" >> "$LOG_FILE"
+    echo "$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ") chronyd-sync-notify[$$]: $1" >> "$LOG_FILE"
 }
 
 

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -56,15 +56,12 @@ touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
 
-if touch "$NTP_FILE"; then
-    chmod 644 "$NTP_FILE"
+if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
     log "Created $NTP_FILE"
 else
-    log "Failed to create $NTP_FILE"
+    log "Failed to create or set permissions on $NTP_FILE"
     exit 1
 fi
-
-
 if [ ! -d "$SYSTEMD_DIR" ]; then
     log "Creating $SYSTEMD_DIR"
     mkdir -p "$SYSTEMD_DIR"

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -55,17 +55,10 @@ if [ ! -f "$CLOCK_EVENT" ]; then
 touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
-# Create required directory
-if [ ! -d "$NTP_DIR" ]; then
-    log "Creating $NTP_DIR"
-    mkdir -p "$NTP_DIR"
-fi
 
-# Create flag files
-
-touch "$NTP_FILE" && log "Created $NTP_FILE"
-log "Change the permission of $NTP_FILE"
-chmod 644 "$NTP_FILE"
+touch "/tmp/systimemgr/ntp" && log "Created $NTP_FILE"
+#log "Change the permission of $NTP_FILE"
+#chmod 644 "$NTP_FILE"
 log "Permission changed for $NTP_FILE"
 
 


### PR DESCRIPTION
Reason for change:
1) Handle the deepsleepoff scenario by executing chronyc burst to select the source and chronyc makestep to ensure time synchronization after wake.
2) Update the quality of Time source as good once NTP sync happened
Test Procedure:
1) Validate that the system time is synchronized correctly after waking from deep sleep.
2) Ensure quality of time source updated to good
Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)