### PR TITLE
RDKEMW-15783:  Handle deepsleep case with chronyd

### DIFF
--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "8ee691e928fe927e05a07f9e1c10bf6a0ecf089d"
+SRCREV_systemtimemgr = "519f014d1bbfcf2ecc135e25c29676bee022a327"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "
@@ -15,7 +15,7 @@ SRC_URI:append = " file://secure.conf "
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 SRCREV_FORMAT = "systemtimemgr"
-PV = "1.5.0"
+PV = "1.5.1"
 PR = "r0"
 
 CXXFLAGS += " -I${PKG_CONFIG_SYSROOT_DIR}/${includedir}/WPEFramework/powercontroller"

--- a/recipes-containers/dobby/dobby.bb
+++ b/recipes-containers/dobby/dobby.bb
@@ -8,6 +8,7 @@ SRC_URI:append = " file://Fix_compile_gcc11.patch  \
                    file://Add_config_header_kirkstone.patch \
                    file://dobby.generic.json \
                    file://dobby_start_after_apparmor.patch \
+                   file://0001-RDKEMW-15176-increased-swap-limit-for-the-container.patch \
                  "
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"

--- a/recipes-containers/dobby/files/0001-RDKEMW-15176-increased-swap-limit-for-the-container.patch
+++ b/recipes-containers/dobby/files/0001-RDKEMW-15176-increased-swap-limit-for-the-container.patch
@@ -1,0 +1,63 @@
+From cc93063fc74c867ad07d69975191b70399d77e7e Mon Sep 17 00:00:00 2001
+From: Gurdal Oruklu <gurdal_oruklu@comcast.com>
+Date: Mon, 9 Mar 2026 20:00:35 +0000
+Subject: [PATCH] RDKEMW-15176: increased swap limit for the container
+
+---
+ bundle/lib/source/DobbySpecConfig.cpp                        | 5 +++++
+ .../lib/source/templates/OciConfigJson1.0.2-dobby.template   | 2 +-
+ .../lib/source/templates/OciConfigJsonVM1.0.2-dobby.template | 2 +-
+ 3 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/bundle/lib/source/DobbySpecConfig.cpp b/bundle/lib/source/DobbySpecConfig.cpp
+index 326d428a..d339dfd9 100644
+--- a/bundle/lib/source/DobbySpecConfig.cpp
++++ b/bundle/lib/source/DobbySpecConfig.cpp
+@@ -62,6 +62,10 @@ static const ctemplate::StaticTemplateString USERNS_DISABLED =
+ 
+ static const ctemplate::StaticTemplateString MEM_LIMIT =
+     STS_INIT(MEM_LIMIT, "MEM_LIMIT");
++static const ctemplate::StaticTemplateString MEM_SWAP_LIMIT =
++    STS_INIT(MEM_SWAP_LIMIT, "MEM_SWAP_LIMIT");
++
++static constexpr unsigned MEM_SWAP_LIMIT_EXTRA_BYTES = 200u * 1024u * 1024u;
+ 
+ static const ctemplate::StaticTemplateString CPU_SHARES_ENABLED =
+     STS_INIT(CPU_SHARES_ENABLED, "CPU_SHARES_ENABLED");
+@@ -1274,6 +1278,7 @@ bool DobbySpecConfig::processMemLimit(const Json::Value& value,
+     }
+ 
+     dictionary->SetIntValue(MEM_LIMIT, memLimit);
++    dictionary->SetIntValue(MEM_SWAP_LIMIT, memLimit + MEM_SWAP_LIMIT_EXTRA_BYTES);
+ 
+     return true;
+ }
+diff --git a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+index 6cbdabd4..6b9dd85f 100644
+--- a/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
++++ b/bundle/lib/source/templates/OciConfigJson1.0.2-dobby.template
+@@ -328,7 +328,7 @@ static const char* ociJsonTemplate = R"JSON(
+             ],
+             "memory": {
+                 "limit": {{MEM_LIMIT}},
+-                "swap": {{MEM_LIMIT}},
++                "swap": {{MEM_SWAP_LIMIT}},
+                 "swappiness": 60
+             },
+             "cpu": {
+diff --git a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+index 21fe91d3..1dc6eb3b 100644
+--- a/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
++++ b/bundle/lib/source/templates/OciConfigJsonVM1.0.2-dobby.template
+@@ -339,7 +339,7 @@ static const char* ociJsonTemplate = R"JSON(
+             ],
+             "memory": {
+                 "limit": {{MEM_LIMIT}},
+-                "swap": {{MEM_LIMIT}},
++                "swap": {{MEM_SWAP_LIMIT}},
+                 "swappiness": 60
+             },
+             "cpu": {
+-- 
+2.34.1
+

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -66,7 +66,7 @@ fi
 
 echo "Synchronized" > /tmp/ntp_status
 
-if [  -d "$NTP_DIR" ]; then
+if [ -d "$NTP_DIR" ]; then
    if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
       log "Created $NTP_FILE"
    else

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -29,8 +29,9 @@ SYSTEMD_DIR="/var/lib/systemd/"
 SYSTEMD_CLOCK="$SYSTEMD_DIR/clock"
 
 log() {
-    echo "$1" >> "$LOG_FILE"
+    echo "$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ") chronyd-sync-notify[$$]: $1" >> "$LOG_FILE"
 }
+
 
 is_synced() {
     chronyc tracking 2>/dev/null | grep -q "Leap status *: Normal"
@@ -54,17 +55,6 @@ if [ ! -f "$CLOCK_EVENT" ]; then
 touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
-# Create required directory
-if [ ! -d "$NTP_DIR" ]; then
-    log "Creating $NTP_DIR"
-    mkdir -p "$NTP_DIR"
-fi
-
-# Create flag files
-if [ ! -f "$NTP_FILE" ]; then
-touch "$NTP_FILE" && log "Created $NTP_FILE"
-fi
-
 if [ ! -d "$SYSTEMD_DIR" ]; then
     log "Creating $SYSTEMD_DIR"
     mkdir -p "$SYSTEMD_DIR"
@@ -75,5 +65,17 @@ touch "$SYSTEMD_CLOCK" && log "Created $SYSTEMD_CLOCK"
 fi
 
 echo "Synchronized" > /tmp/ntp_status
+
+if [  -d "$NTP_DIR" ]; then
+   if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
+      log "Created $NTP_FILE"
+   else
+      log "Failed to create or set permissions on $NTP_FILE"
+      exit 1
+   fi
+else
+   log "Directory $NTP_DIR does not exist; cannot create $NTP_FILE"
+   exit 1
+fi
 
 exit 0


### PR DESCRIPTION
Reason for change:
Handle the deepsleepoff scenario by executing chronyc burst to select the source and chronyc makestep to ensure time synchronization after wake.
Test Procedure:
Validate that the system time is synchronized correctly after waking from deep sleep.
Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com)