### PR TITLE
RDKEMW-15783: Handle deepsleep case with chronyd

### DIFF
--- a/recipes-common/systimemgr/systimemgr_git.bb
+++ b/recipes-common/systimemgr/systimemgr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 DEPENDS = "systimemgrinetrface systimemgrfactory rdk-logger libsyswrapper wpeframework-clientlibraries  telemetry"
 
-SRCREV_systemtimemgr = "8ee691e928fe927e05a07f9e1c10bf6a0ecf089d"
+SRCREV_systemtimemgr = "519f014d1bbfcf2ecc135e25c29676bee022a327"
 SRC_URI = "${CMF_GITHUB_ROOT}/systemtimemgr;${CMF_GITHUB_SRC_URI_SUFFIX};name=systemtimemgr"
 
 SRC_URI:append = " file://systimemgr.conf "
@@ -15,7 +15,7 @@ SRC_URI:append = " file://secure.conf "
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 SRCREV_FORMAT = "systemtimemgr"
-PV = "1.5.0"
+PV = "1.5.1"
 PR = "r0"
 
 CXXFLAGS += " -I${PKG_CONFIG_SYSROOT_DIR}/${includedir}/WPEFramework/powercontroller"

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -66,7 +66,7 @@ fi
 
 echo "Synchronized" > /tmp/ntp_status
 
-if [  -d "$NTP_DIR" ]; then
+if [ -d "$NTP_DIR" ]; then
    if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
       log "Created $NTP_FILE"
    else

--- a/recipes-support/chrony/files/chrony-sync-notify.sh
+++ b/recipes-support/chrony/files/chrony-sync-notify.sh
@@ -29,8 +29,9 @@ SYSTEMD_DIR="/var/lib/systemd/"
 SYSTEMD_CLOCK="$SYSTEMD_DIR/clock"
 
 log() {
-    echo "$1" >> "$LOG_FILE"
+    echo "$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ") chronyd-sync-notify[$$]: $1" >> "$LOG_FILE"
 }
+
 
 is_synced() {
     chronyc tracking 2>/dev/null | grep -q "Leap status *: Normal"
@@ -54,17 +55,6 @@ if [ ! -f "$CLOCK_EVENT" ]; then
 touch "$CLOCK_EVENT" && log "Created $CLOCK_EVENT"
 fi
 
-# Create required directory
-if [ ! -d "$NTP_DIR" ]; then
-    log "Creating $NTP_DIR"
-    mkdir -p "$NTP_DIR"
-fi
-
-# Create flag files
-if [ ! -f "$NTP_FILE" ]; then
-touch "$NTP_FILE" && log "Created $NTP_FILE"
-fi
-
 if [ ! -d "$SYSTEMD_DIR" ]; then
     log "Creating $SYSTEMD_DIR"
     mkdir -p "$SYSTEMD_DIR"
@@ -75,5 +65,17 @@ touch "$SYSTEMD_CLOCK" && log "Created $SYSTEMD_CLOCK"
 fi
 
 echo "Synchronized" > /tmp/ntp_status
+
+if [  -d "$NTP_DIR" ]; then
+   if touch "$NTP_FILE" && chmod 644 "$NTP_FILE"; then
+      log "Created $NTP_FILE"
+   else
+      log "Failed to create or set permissions on $NTP_FILE"
+      exit 1
+   fi
+else
+   log "Directory $NTP_DIR does not exist; cannot create $NTP_FILE"
+   exit 1
+fi
 
 exit 0


### PR DESCRIPTION
**Reason for change:**

1) Handle the deepsleepoff scenario by executing chronyc burst to select the source and chronyc makestep to ensure time synchronization after wake.
2) Update the quality of Time source as good once NTP sync happened

**Test Procedure:**
Validate that the system time is synchronized correctly after waking from deep sleep.
Ensure quality of time source updated to good
Risks: Low
Priority: P1
Signed-off-by: Sindhuja [Sindhuja_Muthukrishnan@comcast.com](mailto:Sindhuja_Muthukrishnan@comcast.com) 