### PR TITLE
RDKEMW-15233: Telemetry Release 1.8.4

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bb
+++ b/recipes-common/telemetry/telemetry_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRCREV = "80657f19eb3c29f4837de13e45ec5a969f946b01"
+SRCREV = "2ae169cccd685b40675275d65e8dd5d07a559f2b"
 SRC_URI = "${CMF_GITHUB_ROOT}/telemetry;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -14,7 +14,7 @@ DEPENDS += "rdk-logger"
 RDEPENDS:${PN} += "curl cjson glib-2.0 rbus"
 
 
-PV = "1.8.1"
+PV = "1.8.4"
 PR = "r0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change: Upgrade the Telemetry Release into 1.8.4 with following ticket changes

- RDKB-63834: Reject and Remove Corrupted Config Files In Persistance 
- RDKB-63722: Build fix for ssl crypto error in platforms with lower ssl version 
- RDKB-63722:Analyze and fix/mitigate memory leaks from curl_easy_perform calls 
- gentic development and maintenance support
- RDKEMW-10467: Fix Invalid time values caused by drift Test Procedure: please refer the ticket comments
Risks: Medium
Signed-off-by: Thamim  Razith <tabbas651@cable.comcast.com>