### PR TITLE
RDKEMW-12176: meta-changes donotmerge

### DIFF
--- a/recipes-connectivity/bluetooth/bluetooth-core_git.bb
+++ b/recipes-connectivity/bluetooth/bluetooth-core_git.bb
@@ -15,7 +15,7 @@ PR = "r2"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
-SRCREV = "f324dbbf9d0372e6a7c0bb5f10edfb4f22ea67ab"
+SRCREV = "f2235cbd7787bc7efb6791e96fc88b03cef470bf"
 SRCREV_FORMAT = "bluetooth-core"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/bluetooth;${CMF_GITHUB_SRC_URI_SUFFIX}"


### PR DESCRIPTION
Reason for change: metaChanges
Test Procedure: Device deepsleep causing the crash
Risks: Low
Priority: P2