### PR TITLE
RDKEMW-16410: Enable rm_work in middleware

### DIFF
--- a/conf/distro/include/rm_work.inc
+++ b/conf/distro/include/rm_work.inc
@@ -1,0 +1,17 @@
+#Enable the rm_work class so the build system automatically removes per-recipe work directories once they are no longer needed (typically after the recipe has successfully produced packages).
+#Key Risk / Developer Impact : Enabling rm_work can delete recipe work directories that developers sometimes use for:
+
+#	editing sources directly under ${TMPDIR}/work/...
+#	manual debugging of build output
+#	post-failure investigation using intermediate artifacts
+
+#Risk: If developers modify/build source code directly in a recipe’s work directory, those changes can be lost when rm_work cleans that recipe.
+
+#Mitigation / Exclusions : Exclude selected recipes from cleanup using RM_WORK_EXCLUDE in local.conf (e.g., recipes actively being developed/debugged):
+#example: RM_WORK_EXCLUDE += "busybox glibc"
+#This allows active development/debug recipes to retain their work directories while the rest of the build benefits from cleanup.
+
+
+INHERIT += "rm_work"
+#Excluding rm_work for middleware-test-image as some oem tasks might need the middleware-test-image's packages after do_rootfs.
+RM_WORK_EXCLUDE += "middleware-test-image"

--- a/conf/distro/include/rm_work.inc
+++ b/conf/distro/include/rm_work.inc
@@ -1,17 +1,17 @@
-#Enable the rm_work class so the build system automatically removes per-recipe work directories once they are no longer needed (typically after the recipe has successfully produced packages).
-#Key Risk / Developer Impact : Enabling rm_work can delete recipe work directories that developers sometimes use for:
+# Enable the rm_work class so the build system automatically removes per-recipe work directories once they are no longer needed (typically after the recipe has successfully produced packages).
 
-#	editing sources directly under ${TMPDIR}/work/...
-#	manual debugging of build output
-#	post-failure investigation using intermediate artifacts
+# Key Risk / Developer Impact : Enabling rm_work can delete recipe work directories that developers sometimes use for:
+# - editing sources directly under ${TMPDIR}/work/...
+# - manual debugging of build output
+# - post-failure investigation using intermediate artifacts
 
-#Risk: If developers modify/build source code directly in a recipe’s work directory, those changes can be lost when rm_work cleans that recipe.
+# Risk: If developers modify/build source code directly in a recipe's work directory, those changes can be lost when rm_work cleans that recipe.
 
-#Mitigation / Exclusions : Exclude selected recipes from cleanup using RM_WORK_EXCLUDE in local.conf (e.g., recipes actively being developed/debugged):
-#example: RM_WORK_EXCLUDE += "busybox glibc"
-#This allows active development/debug recipes to retain their work directories while the rest of the build benefits from cleanup.
+# Mitigation / Exclusions : Exclude selected recipes from cleanup using RM_WORK_EXCLUDE in local.conf (e.g., recipes actively being developed/debugged):
+# example: RM_WORK_EXCLUDE += "busybox glibc"
 
-
+# This allows active development/debug recipes to retain their work directories while the rest of the build benefits from cleanup.
 INHERIT += "rm_work"
-#Excluding rm_work for middleware-test-image as some oem tasks might need the middleware-test-image's packages after do_rootfs.
-RM_WORK_EXCLUDE += "middleware-test-image"
+
+# Excluding rm_work for middleware-test-image as some oem tasks might need the middleware-test-image's packages after do_rootfs.
+RM_WORK_EXCLUDE += "${MLPREFIX}middleware-test-image"

--- a/conf/distro/include/rm_work.inc
+++ b/conf/distro/include/rm_work.inc
@@ -13,5 +13,5 @@
 # This allows active development/debug recipes to retain their work directories while the rest of the build benefits from cleanup.
 INHERIT += "rm_work"
 
-# Excluding rm_work for middleware-test-image as some oem tasks might need the middleware-test-image's packages after do_rootfs.
-RM_WORK_EXCLUDE += "${MLPREFIX}middleware-test-image"
+# Excluding rm_work for middleware-test-image and rdk-fullstack-image as some oem tasks might need the full stack image's packages after do_rootfs.
+RM_WORK_EXCLUDE += "${MLPREFIX}middleware-test-image ${MLPREFIX}rdk-fullstack-image"

--- a/conf/distro/rdk.conf
+++ b/conf/distro/rdk.conf
@@ -258,6 +258,7 @@ VOLATILE_BINDS:append = "/tmp/stunnel.conf /etc/stunnel.conf\n"
 XZ_COMPRESSION_LEVEL ?= "-e -M 50% -9"
 
 include include/rdk-external-src.inc
+include include/rm_work.inc
 
 DISTRO_FEATURES:append = " netflix_wayland_client"
 #DISTRO_FEATURES:append = " netflix_essos_client"


### PR DESCRIPTION
RDKEMW-16410: Reason for change: Enable the rm_work class so the build system automatically removes per-recipe work directories once they are no longer needed (typically after the recipe has successfully produced packages). This is to reduce the overall workspace size.