### PR TITLE
DELIA-70280: [Alpaca DE]Box boot up time is extended post reboot

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bb
+++ b/recipes-common/telemetry/telemetry_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRCREV = "6ec93e1ec9d22bb2e14a2f771b648464f08a71ef"
+SRCREV = "e86b8cf14dab371adcce7b8a34dbf750341b6f2d"
 SRC_URI = "${CMF_GITHUB_ROOT}/telemetry;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -15,7 +15,7 @@ RDEPENDS:${PN} += "curl cjson glib-2.0 rbus"
 
 
 PV = "1.8.5"
-PR = "r0"
+PR = "r1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change:  Updated the git hash id for RBUS handler starvation and race condition on privacyModeVal
Test Procedure: please referr the ticket
Risks: Medium