### PR TITLE
RDKEMW-15927: [Alpaca DE]Box boot up time is extended post reboot - Merge To 8.5

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bb
+++ b/recipes-common/telemetry/telemetry_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRCREV = "6ec93e1ec9d22bb2e14a2f771b648464f08a71ef"
+SRCREV = "96522abbf308cdaa4322034565b10882cebc21d2"
 SRC_URI = "${CMF_GITHUB_ROOT}/telemetry;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -14,7 +14,7 @@ DEPENDS += "rdk-logger"
 RDEPENDS:${PN} += "curl cjson glib-2.0 rbus"
 
 
-PV = "1.8.5"
+PV = "1.8.5v1"
 PR = "r0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change: Updated the git hash id for RBUS handler starvation and race condition on privacyModeVal
Test Procedure: please referr the ticket
Risks: Medium