### PR TITLE
RDKEMW-16923:Xumo TV devices got stuck with old firmware with http error code 405

### DIFF
--- a/recipes-common/utils/commonutilities_git.bb
+++ b/recipes-common/utils/commonutilities_git.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=24691c8ce48996ecd1102d29eab1216e"
 
 # To have a possibility to override SRC_URI later, we are introducing the following workaround:
-SRCREV = "b75c844bf0da6c856dc98f3c13a8e3c8910fc96f"
+SRCREV = "45ef9f4c61483cc735001d3802d305b86c14ec70"
 SRC_URI = "${CMF_GITHUB_ROOT}/common_utilities;module=.;${CMF_GITHUB_SRC_URI_SUFFIX}"
 
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
@@ -24,7 +24,7 @@ LDFLAGS:append = " -lsafec -lsecure_wrapper"
 
 CFLAGS:append = " -DRDK_LOGGER"
 
-PV = "1.5.3"
+PV = "1.5.4"
 PR = "r0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This pull request updates the `commonutilities_git.bb` recipe to pull in the latest source code and version information. The main changes are a version bump and updating the source revision to ensure the recipe uses the most recent code.

Version and source updates:

* Bumped the `PV` (package version) from `1.5.3` to `1.5.4` to reflect the latest release.
* Updated `SRCREV` to `45ef9f4c61483cc735001d3802d305b86c14ec70` to fetch the latest commit from the source repository.