### PR TITLE
RDKEMW-17579 : [support/8.5] Log-backup generated is named with local timestamp instead of UTC timestamp

### DIFF
--- a/recipes-common/dcmd/dcmd.bb
+++ b/recipes-common/dcmd/dcmd.bb
@@ -12,9 +12,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2441d6cdabdc0f370be5cd8a746eb647"
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "ac248aa892992f8914e080eeecba494289373aaf"
+SRCREV = "7bc1c9dc75e674e5aec55eeaaeba76361a37a0e1"
 SRC_URI = "${CMF_GITHUB_ROOT}/dcm-agent;${CMF_GITHUB_SRC_URI_SUFFIX}"
-PV = "2.0.3"
+PV = "2.0.3v1"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 

--- a/recipes-common/dcmd/dcmd.bb
+++ b/recipes-common/dcmd/dcmd.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2441d6cdabdc0f370be5cd8a746eb647"
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "86c47550324d871f804446459dbb0a30814d5a2a"
+SRCREV = "ac248aa892992f8914e080eeecba494289373aaf"
 SRC_URI = "${CMF_GITHUB_ROOT}/dcm-agent;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PV = "2.0.3"
 PR = "r0"


### PR DESCRIPTION
Reason For change : Log-backup generated name change to local time to UTC
Test Procedure: Build and verify
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)