### PR TITLE
RDKEMW-17725: [support/8.5] [ALPACA IT] Device not Going to Deepsleep.

### DIFF
--- a/recipes-common/dcmd/dcmd.bb
+++ b/recipes-common/dcmd/dcmd.bb
@@ -12,9 +12,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2441d6cdabdc0f370be5cd8a746eb647"
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "86c47550324d871f804446459dbb0a30814d5a2a"
+SRCREV = "586b05337125dad2dddd8b017d112d6a1436e11c"
 SRC_URI = "${CMF_GITHUB_ROOT}/dcm-agent;${CMF_GITHUB_SRC_URI_SUFFIX}"
-PV = "2.0.3"
+PV = "2.0.3v3"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
RDKEMW-17725: Updated dcm hotfix tag 