### PR TITLE
RDKEMW-17638: [RDKEMW][ALPACA IT] Device not Going to Deepsleep

### DIFF
--- a/recipes-common/dcmd/dcmd.bb
+++ b/recipes-common/dcmd/dcmd.bb
@@ -12,9 +12,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2441d6cdabdc0f370be5cd8a746eb647"
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "10721084f1b5d32d0bf64cefa8f103eab7b02ad8"
+SRCREV = "7461693af0d9c1c8fbd3fb4fd374ef8858041608"
 SRC_URI = "${CMF_GITHUB_ROOT}/dcm-agent;${CMF_GITHUB_SRC_URI_SUFFIX}"
-PV = "2.1.1"
+PV = "2.1.2"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason for change: Dcm latest release tag update
Test Procedure: Verify build is passing
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)