### PR TITLE
RDK-61088: Replace vendor reboot reason script from shell to C

### DIFF
--- a/recipes-support/reboot-manager/reboot-manager.bb
+++ b/recipes-support/reboot-manager/reboot-manager.bb
@@ -16,7 +16,7 @@ PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 SRC_URI = "${CMF_GITHUB_ROOT}/reboot-manager;${CMF_GITHUB_SRC_URI_SUFFIX};name=reboot-manager"
-SRCREV_reboot-manager = "b4cd16f1844161bb6a3c58167208123a0a413339"
+SRCREV_reboot-manager = "ce60b88739cc411e54751a46ab28db00da2d46eb"
 
 S = "${WORKDIR}/git"
 
@@ -45,6 +45,9 @@ LOGROTATE_SIZE_MEM_rebootInfo = "64000"
 LOGROTATE_ROTATION_MEM_rebootInfo = "3"
 
 DEPENDS += "commonutilities telemetry rbus"
+DEPENDS:append:xumo-mt120v1 = " rdk-reboot-reason-hal-mtk reboot-manager-headers"
+DEPENDS:append:rdktv-us-armv7a = " rdk-reboot-reason-hal-amlogic reboot-manager-headers"
+DEPENDS:append:rdktv-uk-armv7a = " rdk-reboot-reason-hal-amlogic reboot-manager-headers"
 RDEPENDS:${PN}:append = " bash"
 
 CFLAGS:append = " -std=c11 -fPIC -D_GNU_SOURCE -Wall -Werror "


### PR DESCRIPTION
Reason for change: Added code for Reboot reason
Test Procedure: None
Risks: P1
Signed-off-by: najeemabegami <najeemabegam.iqbal@sky.uk>