### PR TITLE
RDKEMW-18086 : 3secDelayTestWithPowerCommit

### DIFF
--- a/recipes-connectivity/bluetooth/bluetooth-mgr_git.bb
+++ b/recipes-connectivity/bluetooth/bluetooth-mgr_git.bb
@@ -8,7 +8,7 @@ PV = "1.0.10"
 PR = "r2"
 
 SRCREV_FORMAT = "bluetooth-mgr"
-SRCREV = "e05efec1f91a2134b3f91198f61c76ba3c4f9fd6"
+SRCREV = "990e3f7db83d998917e335461ef8c62c401264c9"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 SRC_URI = "${CMF_GITHUB_ROOT}/bluetooth_mgr;${CMF_GITHUB_SRC_URI_SUFFIX}"
 SRC_URI:append = " file://btmgr.conf"


### PR DESCRIPTION
Reason for change: Skipped waiting for discovery event from bluez when process termination occurs.
Test Procedure: ensure no regressions with bluetooth feature
Risks: Low
Priority: P0