### PR TITLE
RDKEMW-19246 : Enable firmware-independent OTA Updates for MemInsight

### DIFF
--- a/recipes-devtools/meminsight/files/package.json
+++ b/recipes-devtools/meminsight/files/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "meminsight",
-  "description": "Performance Monitoring tool - meminsight",
-  "version": "1.0.0",
-  "contents": ["meminsight-pkg.tar"],
-  "size": "72K",
+  "name": "meminsight-app",
+  "description": "Performance Monitoring tool - meminsight",
+  "version": "1.0.0",
+  "contents": ["meminsight-app.tar"],
+  "size": "72K",
   "installScript": "/etc/rdm/post-services/start_meminsight.sh"
 }
 

--- a/recipes-devtools/meminsight/files/package.json
+++ b/recipes-devtools/meminsight/files/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "meminsight",
+  "description": "Performance Monitoring tool - meminsight",
+  "version": "1.0.0",
+  "contents": ["meminsight-pkg.tar"],
+  "size": "72K",
+  "installScript": "/etc/rdm/post-services/start_meminsight.sh"
+}
+

--- a/recipes-devtools/meminsight/files/start_meminsight.sh
+++ b/recipes-devtools/meminsight/files/start_meminsight.sh
@@ -18,9 +18,6 @@
 # limitations under the License.
 ##########################################################################
 
-SRC_BIN="/media/apps/meminsight/usr/bin/meminsight"
-DST_BIN="/run/meminsight/usr/bin/meminsight"
-RFC_PARAM="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.meminsight.Trigger"
 
 # Load DEVICE_TYPE
 if [ -f /etc/device.properties ]; then
@@ -43,6 +40,14 @@ case "$DEVICE_TYPE" in
         RDM_LOG_FILE="/var/log/rdm-status.log"
         ;;
 esac
+
+APP_HOME_DIR=/media/apps/${MODEL_NUM}-meminsight
+rm -rf /media/apps/meminsight
+ln -snf "$APP_HOME_DIR" /media/apps/meminsight
+
+SRC_BIN="/media/apps/meminsight/usr/bin/meminsight"
+DST_BIN="/run/meminsight/usr/bin/meminsight"
+RFC_PARAM="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.meminsight.Trigger"
 
 log_info() {
     echo "[start_meminsight] [INFO] $*" >> $RDM_LOG_FILE

--- a/recipes-devtools/meminsight/meminsight_git.bb
+++ b/recipes-devtools/meminsight/meminsight_git.bb
@@ -18,6 +18,7 @@ SRC_URI:append = " file://meminsight-runner.service \
                    file://meminsight-upload.service \
                    file://meminsight-upload.path \
                    file://upload_MemReports.sh \
+                   file://package.json \
                    "
 
 # May 25, 2026

--- a/recipes-support/rdmagent/rdmagent.bb
+++ b/recipes-support/rdmagent/rdmagent.bb
@@ -8,14 +8,14 @@ DEPENDS += "rbus"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8700a1d105cac2a90d4f51290ac6e466"
 
-PV = "2.2.2"
+PV = "2.3.0"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "871e274c8b531bfce3c242f46b1a16c8f2609463"
+SRCREV = "069aaab56ce56cc6c9695c1bab860abfa7162260"
 SRC_URI = "${CMF_GITHUB_ROOT}/rdm-agent;${CMF_GITHUB_SRC_URI_SUFFIX};name=rdmagent"
 SRCREV_FORMAT = "rdmagent"
 


### PR DESCRIPTION
Reason for change: Enable firmware-independent OTA Updates for MemInsight
Test Procedure: Tested and verified
Risks: Low
Priority: P1
Signed-off-by: [RoseMary_Benny@comcast.com](mailto:RoseMary_Benny@comcast.com)