### PR TITLE
RDKEMW-19237 : [support/8.5] -Device Logs tar file available in logbackup folders.

### DIFF
--- a/recipes-common/dcmd/dcmd.bb
+++ b/recipes-common/dcmd/dcmd.bb
@@ -12,9 +12,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2441d6cdabdc0f370be5cd8a746eb647"
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "9338a9b20a811f13ca7be777b994436c7812bfe0"
+SRCREV = "9ccd703b654cc05b2695e25dc391421652f07131"
 SRC_URI = "${CMF_GITHUB_ROOT}/dcm-agent;${CMF_GITHUB_SRC_URI_SUFFIX}"
-PV = "2.0.3v4"
+PV = "2.0.3v6"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason For change : update SRC REV, PV for dcm agent in dcmd.bb