### PR TITLE
RDKEMW-19238 : [develop] -Device Logs tar file available in logbackup folders.

### DIFF
--- a/recipes-common/dcmd/dcmd.bb
+++ b/recipes-common/dcmd/dcmd.bb
@@ -12,9 +12,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=2441d6cdabdc0f370be5cd8a746eb647"
 # This tells bitbake where to find the files we're providing on the local filesystem
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
-SRCREV = "e4ff24f2f5518ececdfa9ea69e8c5142965358d5"
+SRCREV = "0b00b30e28f0847671e228ec421405c85c8e6706"
 SRC_URI = "${CMF_GITHUB_ROOT}/dcm-agent;${CMF_GITHUB_SRC_URI_SUFFIX}"
-PV = "2.1.3"
+PV = "2.1.4"
 PR = "r0"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 


### PR DESCRIPTION
Reason For change : Update dcm-agent 2.1.4 tag