### PR TITLE
RDKEMW-18818: Configure NTP servers with  pool directive

### DIFF
--- a/recipes-support/chrony/files/rdk_chrony.conf
+++ b/recipes-support/chrony/files/rdk_chrony.conf
@@ -1,4 +1,4 @@
 # Configuration values in this file may change dynamically via TR-181 parameters.
 makestep 1.0 3
-pool global-bootstrap-time1.xfinity.com  maxsources 4 iburst minpoll 10 maxpoll 12
-pool global-bootstrap-time2.xfinity.com  maxsources 4 iburst minpoll 10 maxpoll 12
+pool global-bootstrap-time1.xfinity.com maxsources 4 iburst minpoll 10 maxpoll 12
+pool global-bootstrap-time2.xfinity.com maxsources 4 iburst minpoll 10 maxpoll 12

--- a/recipes-support/chrony/files/rdk_chrony.conf
+++ b/recipes-support/chrony/files/rdk_chrony.conf
@@ -1,4 +1,4 @@
 # Configuration values in this file may change dynamically via TR-181 parameters.
 makestep 1.0 3
-pool global-bootstrap-time1.xfinity.com iburst maxsources 4 minpoll 10 maxpoll 12
-pool global-bootstrap-time2.xfinity.com iburst maxsources 4 minpoll 10 maxpoll 12
+pool global-bootstrap-time1.xfinity.com  maxsources 4 iburst minpoll 10 maxpoll 12
+pool global-bootstrap-time2.xfinity.com  maxsources 4 iburst minpoll 10 maxpoll 12

--- a/recipes-support/chrony/files/rdk_chrony.conf
+++ b/recipes-support/chrony/files/rdk_chrony.conf
@@ -1,4 +1,4 @@
 # Configuration values in this file may change dynamically via TR-181 parameters.
 makestep 1.0 3
-server global-bootstrap-time1.xfinity.com iburst minpoll 10 maxpoll 12
-server global-bootstrap-time2.xfinity.com iburst minpoll 10 maxpoll 12
+pool global-bootstrap-time1.xfinity.com iburst maxsources 4 minpoll 10 maxpoll 12
+pool global-bootstrap-time2.xfinity.com iburst maxsources 4 minpoll 10 maxpoll 12


### PR DESCRIPTION
Reason for change - The NTP servers are configured using the server directive in chrony.conf. With this configuration, DNS resolution occurs only once during startup, and Chrony selects one of the resolved IP addresses. If the selected address is an IPv6 address, Chrony sends NTP requests to the server, but no response is received.

Configure the NTP servers using the pool directive instead of the server directive. The pool directive performs periodic DNS re-resolution of the configured hostnames, allowing Chrony to select alternate addresses when needed, which effectively mitigates the issue.