### PR TITLE
RDKEVD-8621 : consume OSS 4.14.0 in Vendor - Amlogic

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -32,6 +32,7 @@ BBLAYERS =+ " ${@d.getVar('MANIFEST_PATH_VENDOR_IMAGE_PACKAGER') if d.getVar('MA
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_OSS_RELEASE') if d.getVar('MANIFEST_PATH_OSS_RELEASE') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_OSS_RELEASE') + '/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_VENDOR_RELEASE') if d.getVar('MANIFEST_PATH_VENDOR_RELEASE') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_VENDOR_RELEASE') + '/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_CSPC_SECURITY_RELEASE') if d.getVar('MANIFEST_PATH_CSPC_SECURITY_RELEASE') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_CSPC_SECURITY_RELEASE') + '/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@d.getVar('MANIFEST_PATH_META_RDK_BLUETOOTH') if d.getVar('MANIFEST_PATH_META_RDK_BLUETOOTH') is not None and os.path.isfile(d.getVar('MANIFEST_PATH_META_RDK_BLUETOOTH') + '/conf/layer.conf') else ''}"
 
 # Release layers: restricted/proprietary/optional
 BBLAYERS =+ " \


### PR DESCRIPTION
https://ccp.sys.comcast.net/browse/RDKEVD-8621
---
Need to add meta-rdk-bluetooth in middleware's submanifest rdke-middleware-generic-manifest/middleware-generic.xml ---
avoid following build issue
ERROR: lib32-bluetooth-core-1.0.11-r2 do_compile: oe_runmake failed ERROR: lib32-bluetooth-core-1.0.11-r2 do_compile: ExecutionError('/home/ubuntu/builds/rdk-e/rdk-yocto-gha-jobs/build-rdktv-us-armv8a/tmp-debug/work/rdktv-us-armv8a-middleware-rdkmllib32-linux-gnueabi/lib32-bluetooth-core/1.0.11-r2/temp/run.do_compile.3921300', 1, None, None)

| ../../git/src/btrCore_avMedia.c:52:10: fatal error: bluetooth/audio/a2dp-codecs.h: No such file or directory
|    52 | #include <bluetooth/audio/a2dp-codecs.h>
|       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---