### PR TITLE
RDKEMW-23702: Propagate seek-map clearing across log-upload profiles

### DIFF
--- a/recipes-common/telemetry/telemetry_git.bb
+++ b/recipes-common/telemetry/telemetry_git.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-SRCREV = "ff823cd555a2dcdffe439a183a70b1c655df3087"
+SRCREV = "e6b31018541e140f2100f01ab8fc62a0013a3ffe"
 SRC_URI = "${CMF_GITHUB_ROOT}/telemetry;${CMF_GITHUB_SRC_URI_SUFFIX}"
 PACKAGE_ARCH = "${MIDDLEWARE_ARCH}"
 
@@ -15,7 +15,7 @@ RDEPENDS:${PN} += "curl cjson glib-2.0 rbus"
 
 
 PV = "1.9.9"
-PR = "r0"
+PR = "r1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change: Fix a race where concurrent profile timeout threads consumed a shared retain-seek flag, causing only one profile to clear its grep seek map after log upload. Store and propagate the clear-seek decision per profile, and update related tests.This ensures all profiles clear their grep seek maps after a log upload, preventing stale seek positions from causing log markers such as Total_5G_clients_split to be missed after log files are truncated or rotated.
Test Procedure: Refer the ticket descriptions
Risks: Medium
Priority: P0